### PR TITLE
chore(patch): enable pwritev() [sc-3462]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,6 +20,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "CLMDB",
-            dependencies: []),
+            dependencies: [],
+            cSettings: [
+                .define("MDB_USE_PWRITEV"),
+            ]),
     ]
 )


### PR DESCRIPTION
Make LMDB use pwritev() syscall.

This can improve performance by reducing the number of syscalls (i.e. user <-> kernel transitions).

Fixes Shortcut story [[sc-2898](https://app.shortcut.com/ordo-one/story/2898)]

Corresponding PR to upstream: https://github.com/apple/swift-lmdb/pull/3